### PR TITLE
feat: add disable auto save only option

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 AccWideUILayoutSelection/Libs
+.luacheckrc

--- a/AccWideUILayoutSelection/Core.lua
+++ b/AccWideUILayoutSelection/Core.lua
@@ -14,13 +14,13 @@ AccWideUIAceAddon.TempData = {
 function AccWideUIAceAddon:OnInitialize()
 
 	self.db = LibStub("AceDB-3.0"):New("AccWideUIAceDB", AccWideUIAceAddon:GenerateDefaultDB(), true)
-	
+
 	if (AccWideUI_AccountData ~= nil and AccWideUI_AccountData.HasDoneV1Migration ~= true) then
 		AccWideUIAceAddon:MigrateFromV1()
 	end
-	
+
 	AccWideUI_AccountData = nil
-	
+
 end
 
 function AccWideUIAceAddon:OnEnable()
@@ -34,23 +34,23 @@ function AccWideUIAceAddon:OnEnable()
 	self.optionsData.args.profiles = profiles
 	self.optionsData.args.profiles.order = 4
 	AC:RegisterOptionsTable("AccWideUIAceAddon_Options", self.optionsData)
-	
+
 	self.optionsFrame = ACD:AddToBlizOptions("AccWideUIAceAddon_Options", L["ACCWUI_ADDONNAME_SHORT"])
-	
+
 	self.db.RegisterCallback(self, "OnNewProfile", "DoProfileInit")
     self.db.RegisterCallback(self, "OnProfileChanged", "DoProfileInit")
     self.db.RegisterCallback(self, "OnProfileCopied", "DoProfileInit")
     self.db.RegisterCallback(self, "OnProfileReset", "DoProfileInit")
-	
+
 	self.db.RegisterCallback(self, "OnProfileShutdown", "DoBeforeProfileShutdown")
 	self.db.RegisterCallback(self, "OnDatabaseShutdown", "DoBeforeProfileShutdown")
-	
+
 	self:RegisterChatCommand("accwideui", "SlashCommand")
 	self:RegisterChatCommand("accwideeditmode", "SlashCommand")
 	self:RegisterChatCommand("accwideinterface", "SlashCommand")
 	self:RegisterChatCommand("accwide", "SlashCommand")
 	self:RegisterChatCommand("awi", "SlashCommand")
-	
+
 	self:DoProfileInit("OnEnable")
 
 	self:RegisterEvent("CHANNEL_UI_UPDATE")
@@ -61,35 +61,35 @@ function AccWideUIAceAddon:OnEnable()
 	self:RegisterEvent("CINEMATIC_STOP")
 	self:RegisterEvent("PLAYER_REGEN_ENABLED")
 	self:RegisterEvent("PLAYER_REGEN_DISABLED")
-	
+
 	if (AccWideUIAceAddon:IsMainline()) then
 		self:RegisterEvent("ACTIVE_TALENT_GROUP_CHANGED")
 		self:RegisterEvent("BAG_SLOT_FLAGS_UPDATED")
 		self:RegisterEvent("BANK_BAG_SLOT_FLAGS_UPDATED")
 		self:RegisterEvent("LET_RECENT_ALLIES_SEE_LOCATION_SETTING_UPDATED")
 	end
-	
-	
+
+
 	C_AddOns.LoadAddOn("Blizzard_BattlefieldMap")
-	
+
 	self:SecureHook(BattlefieldMapTab, "StopMovingOrSizing", function()
 		if (self.db.global.printDebugTextToChat == true) then
 			self:Print("[Zone Map] Saving Map Coords.")
 		end
-	
+
 		-- Save Zone Map Coords
 		if ((self.db.profile.syncToggles.battlefieldMap == true) and (self.db.global.hasDoneFirstTimeSetup == true)) then
-			if self.db.global.useScreenSizeSpecificSettings == true then	
+			if self.db.global.useScreenSizeSpecificSettings == true then
 				self.db.profile.syncData.screenResolutionSpecific[self.TempData.ScreenRes].battlefieldMap.options.position = {}
 				self.db.profile.syncData.screenResolutionSpecific[self.TempData.ScreenRes].battlefieldMap.options.position.x, self.db.profile.syncData.battlefieldMap.options.position.y = BattlefieldMapTab:GetCenter()
-			else 
+			else
 				self.db.profile.syncData.battlefieldMap.options.position = {}
 				self.db.profile.syncData.battlefieldMap.options.position.x, self.db.profile.syncData.battlefieldMap.options.position.y = BattlefieldMapTab:GetCenter()
 			end
-		end	
+		end
 	end)
-	
-	
+
+
 	if (self:IsMainline() or self:IsClassicTBC()) then
 		self:SecureHook(C_EditMode, "OnEditModeExit", function()
 			if (C_AddOns.IsAddOnLoaded("EditModeExpanded") == true and not self.TempData.EditModeExpandedTriggered) then
@@ -98,7 +98,7 @@ function AccWideUIAceAddon:OnEnable()
 				end
 				self.TempData.EditModeExpandedTriggered = true
 			else
-				if (self.db.global.disableAutoSaveLoad == false) then
+				if (self.db.global.disableAutoSaveLoad == false and self.db.global.disableAutoSave == false) then
 					self:SaveEditModeSettings()
 					if (self.db.global.printDebugTextToChat == true) then
 						self:Print("[Debug] Saving Edit Mode Layout on EditModeExit.")
@@ -107,81 +107,81 @@ function AccWideUIAceAddon:OnEnable()
 			end
 		end)
 	end
-	
-	
-	if (self:IsMainline()) then	
+
+
+	if (self:IsMainline()) then
 		self:SecureHook(C_Container, "SetSortBagsRightToLeft", function(thisResponse)
-			if (self.db.global.allowExperimentalSyncs == true and self.db.profile.syncToggles.bagOrganisation == true and self.db.global.disableAutoSaveLoad == false) then
+			if (self.db.global.allowExperimentalSyncs == true and self.db.profile.syncToggles.bagOrganisation == true and self.db.global.disableAutoSaveLoad == false and self.db.global.disableAutoSave == false) then
 				self.db.profile.syncData.bagOrganisation.settings.sortBagsRightToLeft = thisResponse
 				if (self.db.global.printDebugTextToChat == true) then
 					self:Print("[Bags] Set sortBagsRightToLeft to " .. tostring(thisResponse) .. ".")
 				end
 			end
 		end)
-		
-		
+
+
 		self:SecureHook(C_Container, "SetInsertItemsLeftToRight", function(thisResponse)
-			if (self.db.global.allowExperimentalSyncs == true and self.db.profile.syncToggles.bagOrganisation == true and self.db.global.disableAutoSaveLoad == false) then
+			if (self.db.global.allowExperimentalSyncs == true and self.db.profile.syncToggles.bagOrganisation == true and self.db.global.disableAutoSaveLoad == false and self.db.global.disableAutoSave == false) then
 				self.db.profile.syncData.bagOrganisation.settings.insertItemsLeftToRight = thisResponse
 				if (self.db.global.printDebugTextToChat == true) then
 					self:Print("[Bags] Set insertItemsLeftToRight to " .. tostring(thisResponse) .. ".")
 				end
 			end
 		end)
-	
-		
-		
+
+
+
 		self:SecureHook(C_Container, "SetBackpackAutosortDisabled", function(thisResponse)
-			if (self.db.global.allowExperimentalSyncs == true and self.db.profile.syncToggles.bagOrganisation == true and self.db.global.disableAutoSaveLoad == false) then
+			if (self.db.global.allowExperimentalSyncs == true and self.db.profile.syncToggles.bagOrganisation == true and self.db.global.disableAutoSaveLoad == false and self.db.global.disableAutoSave == false) then
 				self.db.profile.syncData.bagOrganisation.settings.backpackAutosortDisabled = thisResponse
 				if (self.db.global.printDebugTextToChat == true) then
 					self:Print("[Bags] Set backpackAutosortDisabled to " .. tostring(thisResponse) .. ".")
 				end
 			end
 		end)
-		
-		
+
+
 		self:SecureHook(C_Container, "SetBackpackSellJunkDisabled", function(thisResponse)
-			if (self.db.global.allowExperimentalSyncs == true and self.db.profile.syncToggles.bagOrganisation == true and self.db.global.disableAutoSaveLoad == false) then
+			if (self.db.global.allowExperimentalSyncs == true and self.db.profile.syncToggles.bagOrganisation == true and self.db.global.disableAutoSaveLoad == false and self.db.global.disableAutoSave == false) then
 				self.db.profile.syncData.bagOrganisation.settings.backpackSellJunkDisabled = thisResponse
 				if (self.db.global.printDebugTextToChat == true) then
 					self:Print("[Bags] Set backpackSellJunkDisabled to " .. tostring(thisResponse) .. ".")
 				end
 			end
 		end)
-		
-		
+
+
 		self:SecureHook(C_Container, "SetBankAutosortDisabled", function(thisResponse)
-			if (self.db.global.allowExperimentalSyncs == true and self.db.profile.syncToggles.bagOrganisation == true and self.db.global.disableAutoSaveLoad == false) then
+			if (self.db.global.allowExperimentalSyncs == true and self.db.profile.syncToggles.bagOrganisation == true and self.db.global.disableAutoSaveLoad == false and self.db.global.disableAutoSave == false) then
 				self.db.profile.syncData.bagOrganisation.settings.bankAutosortDisabled = thisResponse
 				if (self.db.global.printDebugTextToChat == true) then
 					self:Print("[Bags] Set bankAutosortDisabled to " .. tostring(thisResponse) .. ".")
 				end
 			end
 		end)
-		
-		
+
+
 		self:SecureHook("SetAutoDeclineNeighborhoodInvites", function(thisResponse)
-			if (self.db.profile.syncToggles.blockNeighborhoodInvites == true and self.db.global.disableAutoSaveLoad == false and self.TempData.IsCurrentlyLoadingSettings == false) then
+			if (self.db.profile.syncToggles.blockNeighborhoodInvites == true and self.db.global.disableAutoSaveLoad == false and self.db.global.disableAutoSave == false and self.TempData.IsCurrentlyLoadingSettings == false) then
 				self.db.profile.syncData.blockNeighborhoodInvites.special.blockNeighborhoodInvites = thisResponse
 			end
 		end)
 
 	end
-	
+
 
 end
 
 function AccWideUIAceAddon:DoProfileInit(event, db, profileKey)
-	
+
 	do
 		-- Nil old variables
 		self.db.profile.syncToggles.blockSocial = nil
 		self.db.profile.syncData.blockSocial = nil
 		self.db.profile.syncData.mouseoverCast.cvars.autoSelfCast = nil
 	end
-	
-	
+
+
 	-- Edit Mode Spec Settings
 	if (self.db.char.useEditModeLayout.hasBeenPrepared ~= true) then
 		for SpecX = 1, 5 do
@@ -189,30 +189,30 @@ function AccWideUIAceAddon:DoProfileInit(event, db, profileKey)
 		end
 		self.db.char.useEditModeLayout.hasBeenPrepared = true
 	end
-	
+
 
 	--Set up profile data that I can't do with the regular table
 	if (event == "OnNewProfile") then
-	
+
 		if (self.db.global.printDebugTextToChat == true) then
 			self:Print("[Debug] Profile Created.")
 		end
-	
+
 		--Block Guild Invites
 		if (not self.db.profile.syncData.blockGuildInvites.special.blockGuildInvites) then
 			self.db.profile.syncData.blockGuildInvites.special.blockGuildInvites = GetAutoDeclineGuildInvites()
 		end
-		
-		
-		
+
+
+
 		if (AccWideUIAceAddon:IsMainline() == true) then
-		
+
 			--Block Neighborhood Invites
 			if (not self.db.profile.syncData.blockNeighborhoodInvites.special.blockNeighborhoodInvites) then
 				self.db.profile.syncData.blockNeighborhoodInvites.special.blockNeighborhoodInvites = GetAutoDeclineNeighborhoodInvites()
 			end
-		
-			self:ScheduleTimer(function() 
+
+			self:ScheduleTimer(function()
 				--Bag Organisation
 				self.db.profile.syncData.bagOrganisation.settings.sortBagsRightToLeft = C_Container.GetSortBagsRightToLeft() or false
 				self.db.profile.syncData.bagOrganisation.settings.insertItemsLeftToRight = C_Container.GetInsertItemsLeftToRight() or false
@@ -220,68 +220,68 @@ function AccWideUIAceAddon:DoProfileInit(event, db, profileKey)
 				self.db.profile.syncData.bagOrganisation.settings.backpackAutosortDisabled =  C_Container.GetBackpackSellJunkDisabled() or false
 				self.db.profile.syncData.bagOrganisation.settings.bankAutosortDisabled = C_Container.GetBankAutosortDisabled() or false
 			end, 2)
-			
-						
+
+
 			-- Edit Mode
 			if (type(self.db.profile.syncData.editModeLayoutID) ~= "number") then
 				local getLayoutsTable = C_EditMode.GetLayouts()
 				local currentActiveLayout = getLayoutsTable["activeLayout"]
-				
+
 				self.db.profile.syncData.editModeLayoutID = currentActiveLayout or 1
-				
+
 				if self.db.global.useScreenSizeSpecificSettings == true then
 					self.db.profile.syncData.screenResolutionSpecific[AccWideUIAceAddon.TempData.ScreenRes].editModeLayoutID = currentActiveLayout or 1
 				end
-				
+
 				if (self.db.global.printDebugTextToChat == true) then
 					self:Print("[Debug] Setting default Edit Mode.")
 				end
-					
+
 			end
-		
+
 		end
-		
+
 	end
-	
-	
+
+
 	if (event == "OnProfileChanged" or event == "OnProfileCopied") then
-		
+
 		if (self.db.global.printDebugTextToChat == true) then
 			self:Print("[Debug] Profile Changed.")
 		end
-	
+
 		if (not InCombatLockdown()) then
 			if (self.db.global.disableAutoSaveLoad == false) then
 				if (C_AddOns.IsAddOnLoaded("EditModeExpanded") == true and not self.TempData.EditModeExpandedTriggered) then
 					 self.TempData.EditModeExpandedTriggered = true
 				end
 				self:CancelAllTimers()
-				self:ScheduleTimer(function() 
-					self:LoadUISettings()			
+				self:ScheduleTimer(function()
+					self:LoadUISettings()
 				end, 2)
-			
+
 			end
 		else
 			self:Print(L["ACCWUI_WAIT_TILL_COMBAT"])
 			self.TempData.LoadSettingsAfterCombat = true
 		end
 	end
-	
+
 	if (event == "OnProfileReset") then
 		if (self.db.global.printDebugTextToChat == true) then
 			self:Print("[Debug] Profile Reset.")
 		end
-	
+
 		self:CancelAllTimers()
 	end
-	
-	
+
+
 end
 
 
 
 function AccWideUIAceAddon:DoBeforeProfileShutdown(event, db, profileKey)
-	if (self.db.global.hasDoneFirstTimeSetup == true and self.db.global.disableAutoSaveLoad == false) then
+	if (self.db.global.hasDoneFirstTimeSetup == true and self.db.global.disableAutoSaveLoad == false and self.db.global.disableAutoSave == false) then
 		self:SaveUISettings(true)
 	end
 end
@@ -289,30 +289,30 @@ end
 
 
 function AccWideUIAceAddon:SlashCommand(input, editbox)
-	
+
 	if not input or input:trim() == "" then
 		Settings.OpenToCategory(self.optionsFrame.name)
 	elseif input:lower() == "save" or input:lower() == "profiles save" then
-		AccWideUIAceAddon:ForceSaveSettings() 	
+		AccWideUIAceAddon:ForceSaveSettings()
 	elseif input:lower() == "load" or input:lower() == "profiles load" then
-		AccWideUIAceAddon:ForceLoadSettings() 
+		AccWideUIAceAddon:ForceLoadSettings()
 	else
 		LibStub("AceConfigCmd-3.0").HandleCommand(AccWideUIAceAddon, "awi", "AccWideUIAceAddon_Options", input)
 	end
-	
+
 end
 
 
 
 
 function AccWideUIAceAddon:BlizzChannelManager()
-	
+
 	if (C_AddOns.IsAddOnLoaded("BlockBlizzChatChannels") == false) then
 
 		if (self.db.global.hasDoneFirstTimeSetup == true) then
-		
-			
-			
+
+
+
 			-- Join player to channels if they're allowed
 			if (self.db.profile.blizzChannels.general == "join") then
 				if (((GetChannelName(self.chatChannelNames.general))) == 0) then
@@ -327,7 +327,7 @@ function AccWideUIAceAddon:BlizzChannelManager()
 					end
 				end
 			end
-			
+
 			if (self.db.profile.blizzChannels.localDefense == "join") then
 				if (((GetChannelName(self.chatChannelNames.localDefense))) == 0) then
 					JoinChannelByName(self.chatChannelNames.localDefense)
@@ -341,7 +341,7 @@ function AccWideUIAceAddon:BlizzChannelManager()
 					end
 				end
 			end
-			
+
 			if (self.db.profile.blizzChannels.trade == "join") then
 				if (((GetChannelName(self.chatChannelNames.trade))) == 0) then
 					JoinChannelByName(self.chatChannelNames.trade)
@@ -350,13 +350,13 @@ function AccWideUIAceAddon:BlizzChannelManager()
 					else
 						ChatFrameMixin.AddChannel(DEFAULT_CHAT_FRAME, self.chatChannelNames.trade) -- 12.0.0
 					end
-					
+
 					if (self.db.global.printBlizzChatChanges == true) then
 						self:Printf(L["ACCWUI_JOINING_CHANNEL"], self.chatChannelNames.trade, self.TempData.TextSlash)
 					end
 				end
 			end
-			
+
 			if (self.db.profile.blizzChannels.lookingForGroup == "join") then
 				if (((GetChannelName(self.chatChannelNames.lookingForGroup))) == 0) then
 					JoinChannelByName(self.chatChannelNames.lookingForGroup)
@@ -370,7 +370,7 @@ function AccWideUIAceAddon:BlizzChannelManager()
 					end
 				end
 			end
-			
+
 			if (self:IsMainline() or self:IsClassicEra()) then
 				if (self.db.profile.blizzChannels.services == "join") then
 					if (((GetChannelName(self.chatChannelNames.services))) == 0) then
@@ -386,7 +386,7 @@ function AccWideUIAceAddon:BlizzChannelManager()
 					end
 				end
 			end
-			
+
 			if (self:IsMainline() == false) then
 				if (self.db.profile.blizzChannels.worldDefense == "join") then
 					if (((GetChannelName(self.chatChannelNames.worldDefense))) == 0) then
@@ -402,8 +402,8 @@ function AccWideUIAceAddon:BlizzChannelManager()
 					end
 				end
 			end
-			
-			
+
+
 			if (self:IsClassicEra() or self:IsClassicWrath()) then
 				if (self.db.profile.blizzChannels.guildRecruitment == "join") then
 					if (((GetChannelName(self.chatChannelNames.guildRecruitment))) == 0) then
@@ -419,7 +419,7 @@ function AccWideUIAceAddon:BlizzChannelManager()
 					end
 				end
 			end
-				
+
 			if (self:IsClassicEra()) then
 				if (self.db.profile.blizzChannels.hardcoreDeaths == "join") then
 					if (((GetChannelName(self.chatChannelNames.hardcoreDeaths))) == 0) then
@@ -434,10 +434,10 @@ function AccWideUIAceAddon:BlizzChannelManager()
 						end
 					end
 				end
-			end	
-		
-		
-		
+			end
+
+
+
 			-- Remove player from channels if they're blocked
 			if (self.db.profile.blizzChannels.general == "block") then
 				if (GetChannelName((GetChannelName(self.chatChannelNames.general))) > 0) then
@@ -447,25 +447,25 @@ function AccWideUIAceAddon:BlizzChannelManager()
 					end
 				end
 			end
-			
+
 			if (self.db.profile.blizzChannels.localDefense == "block") then
 				if (GetChannelName((GetChannelName(self.chatChannelNames.localDefense))) > 0) then
 					LeaveChannelByName(self.chatChannelNames.localDefense)
 					if (self.db.global.printBlizzChatChanges == true) then
-						self:Printf(L["ACCWUI_LEAVING_CHANNEL"], self.chatChannelNames.localDefense, self.TempData.TextSlash)	
+						self:Printf(L["ACCWUI_LEAVING_CHANNEL"], self.chatChannelNames.localDefense, self.TempData.TextSlash)
 					end
 				end
 			end
-			
+
 			if (self.db.profile.blizzChannels.trade == "block") then
 				if (GetChannelName((GetChannelName(self.chatChannelNames.trade))) > 0) then
 					LeaveChannelByName(self.chatChannelNames.trade)
 					if (self.db.global.printBlizzChatChanges == true) then
-						self:Printf(L["ACCWUI_LEAVING_CHANNEL"], self.chatChannelNames.trade, self.TempData.TextSlash)	
+						self:Printf(L["ACCWUI_LEAVING_CHANNEL"], self.chatChannelNames.trade, self.TempData.TextSlash)
 					end
 				end
 			end
-			
+
 			if (self.db.profile.blizzChannels.lookingForGroup == "block") then
 				if (GetChannelName((GetChannelName(self.chatChannelNames.lookingForGroup))) > 0) then
 					LeaveChannelByName(self.chatChannelNames.lookingForGroup)
@@ -474,7 +474,7 @@ function AccWideUIAceAddon:BlizzChannelManager()
 					end
 				end
 			end
-			
+
 			if (self:IsMainline() or self:IsClassicEra()) then
 				if (self.db.profile.blizzChannels.services == "block") then
 					if (GetChannelName((GetChannelName(self.chatChannelNames.services))) > 0) then
@@ -485,7 +485,7 @@ function AccWideUIAceAddon:BlizzChannelManager()
 					end
 				end
 			end
-			
+
 			if (self:IsMainline() == false) then
 				if (self.db.profile.blizzChannels.worldDefense == "block") then
 					if (GetChannelName((GetChannelName(self.chatChannelNames.worldDefense))) > 0) then
@@ -496,8 +496,8 @@ function AccWideUIAceAddon:BlizzChannelManager()
 					end
 				end
 			end
-			
-			
+
+
 			if (self:IsClassicEra() or self:IsClassicWrath()) then
 				if (self.db.profile.blizzChannels.guildRecruitment == "block") then
 					if (GetChannelName((GetChannelName(self.chatChannelNames.guildRecruitment))) > 0) then
@@ -508,7 +508,7 @@ function AccWideUIAceAddon:BlizzChannelManager()
 					end
 				end
 			end
-				
+
 			if (self:IsClassicEra()) then
 				if (self.db.profile.blizzChannels.hardcoreDeaths == "block") then
 					if (GetChannelName((GetChannelName(self.chatChannelNames.hardcoreDeaths))) > 0) then
@@ -518,15 +518,15 @@ function AccWideUIAceAddon:BlizzChannelManager()
 						end
 					end
 				end
-			end	
-			
-			
-			
+			end
+
+
+
 
 		end
 
 	end
-	
+
 end
 
 
@@ -534,42 +534,42 @@ end
 function AccWideUIAceAddon:LOADING_SCREEN_DISABLED(event, arg1, arg2)
 
 	if (not self.TempData.HasDoneInitialLoad) then
-	
+
 		if (self.db.global.disableAutoSaveLoad == false) then
-		
+
 			if (self.db.global.hasDoneFirstTimeSetup == true) then
-				
+
 				if (self.db.global.printDebugTextToChat == true) then
 					self:Print("[Debug] Doing Initial Load.")
 				end
-				
+
 				if (self.db.global.enableTextOutput == true) then
 					self:Printf(L["ACCWUI_LOAD_REGULAR"], self.TempData.TextSlash)
 				end
-				
+
 				if (not InCombatLockdown()) then
-					self:ScheduleTimer(function() 
+					self:ScheduleTimer(function()
 						self:LoadUISettings()
 					end, 5)
 				else
 					self:Print(L["ACCWUI_WAIT_TILL_COMBAT"])
 					self.TempData.LoadSettingsAfterCombat = true
 				end
-				
+
 			else
-			
+
 				StaticPopup_Show("ACCWIDEUI_FIRSTTIMEPOPUP")
 				--self:Print("Show First Time Popup")
-			
+
 			end
-		
+
 		end
-	
+
 		self.TempData.HasDoneInitialLoad = true
-	
+
 	end
-	
-	
+
+
 end
 
 
@@ -580,26 +580,26 @@ function AccWideUIAceAddon:CHANNEL_UI_UPDATE(event, arg1, arg2)
 end
 
 function AccWideUIAceAddon:ZONE_CHANGED_NEW_AREA(event, arg1, arg2)
-	self:ScheduleTimer(function() 
+	self:ScheduleTimer(function()
 		self:BlizzChannelManager()
 	end, 5)
 end
 
 
 function AccWideUIAceAddon:CINEMATIC_STOP(event, arg1, arg2)
-	
+
 	if (not self.TempData.HasShownFTPPopup) then
-		
-		C_Timer.After(5, function() 
+
+		C_Timer.After(5, function()
 			if (self.db.global.hasDoneFirstTimeSetup ~= true and not self.TempData.HasDimissedFTPAlready) then
 				StaticPopup_Show("ACCWIDEUI_FIRSTTIMEPOPUP")
 			end
 		end)
-		
+
 		self.TempData.HasShownFTPPopup = true
-		
+
 	end
-	
+
 end
 
 
@@ -621,7 +621,7 @@ end
 
 function AccWideUIAceAddon:ACTIVE_TALENT_GROUP_CHANGED(event, arg1, arg2)
 	if (self.TempData.HasDoneInitialLoad) then
-		self:ScheduleTimer(function() 
+		self:ScheduleTimer(function()
 			self:LoadEditModeSettings()
 		end, 0.5)
 	end
@@ -630,7 +630,7 @@ end
 
 
 function AccWideUIAceAddon:BAG_SLOT_FLAGS_UPDATED(event, arg1, arg2)
-	if (self.db.global.hasDoneFirstTimeSetup == true and self.db.global.disableAutoSaveLoad == false and self:IsMainline() == true) then
+	if (self.db.global.hasDoneFirstTimeSetup == true and self.db.global.disableAutoSaveLoad == false and self.db.global.disableAutoSave == false and self:IsMainline() == true) then
 		if (self.db.global.allowExperimentalSyncs == true) then
 			if (self.db.profile.syncToggles.bagOrganisation == true and self.TempData.IsCurrentlyLoadingSettings == false) then
 				self:SaveBagFlagSettings()
@@ -642,7 +642,7 @@ end
 
 
 function AccWideUIAceAddon:BANK_BAG_SLOT_FLAGS_UPDATED(event, arg1, arg2)
-	if (self.db.global.hasDoneFirstTimeSetup == true and self.db.global.disableAutoSaveLoad == false and self:IsMainline() == true) then
+	if (self.db.global.hasDoneFirstTimeSetup == true and self.db.global.disableAutoSaveLoad == false and self.db.global.disableAutoSave == false and self:IsMainline() == true) then
 		if (self.db.global.allowExperimentalSyncs == true) then
 			if (self.db.profile.syncToggles.bagOrganisation == true and self.TempData.IsCurrentlyLoadingSettings == false) then
 				self:SaveBagFlagSettings()
@@ -652,13 +652,13 @@ function AccWideUIAceAddon:BANK_BAG_SLOT_FLAGS_UPDATED(event, arg1, arg2)
 end
 
 function AccWideUIAceAddon:LET_RECENT_ALLIES_SEE_LOCATION_SETTING_UPDATED(event, arg1, arg2)
-	if (self.db.global.hasDoneFirstTimeSetup == true and self.db.global.disableAutoSaveLoad == false and self:IsMainline() == true) then
+	if (self.db.global.hasDoneFirstTimeSetup == true and self.db.global.disableAutoSaveLoad == false and self.db.global.disableAutoSave == false and self:IsMainline() == true) then
 		if (self.db.profile.syncToggles.locationVisibility == true) then
 			self.db.profile.syncData.locationVisibility.special.allowRecentAlliesSeeLocation = GetAllowRecentAlliesSeeLocation()
 			if (self.db.global.printDebugTextToChat == true) then
 				self:Print("[Location Visibility] Setting Changed.")
 			end
-			
+
 		end
 	end
 end
@@ -667,8 +667,8 @@ end
 function AccWideUIAceAddon:PLAYER_REGEN_ENABLED(event, arg1, arg2)
 	if (self.TempData.LoadSettingsAfterCombat == true) then
 		self.TempData.LoadSettingsAfterCombat = false
-		self:CancelAllTimers(); 
-		self:ScheduleTimer(function() 
+		self:CancelAllTimers();
+		self:ScheduleTimer(function()
 			self:LoadUISettings()
 		end, 3)
 	end
@@ -678,7 +678,7 @@ function AccWideUIAceAddon:PLAYER_REGEN_DISABLED(event, arg1, arg2)
 	if (self.TempData.IsCurrentlyLoadingSettings == true) then
 		self.TempData.IsCurrentlyLoadingSettings = false
 		self.TempData.LoadSettingsAfterCombat = true
-		self:CancelAllTimers(); 
+		self:CancelAllTimers();
 		if (self.db.global.printDebugTextToChat == true) then
 			self:Print(L["ACCWUI_WAIT_TILL_COMBAT"])
 		end

--- a/AccWideUILayoutSelection/Options.lua
+++ b/AccWideUILayoutSelection/Options.lua
@@ -5,6 +5,7 @@ function AccWideUIAceAddon:GenerateDefaultDB()
 	local defaults = {
 		global = {
 			disableAutoSaveLoad = false,
+			disableAutoSave = false,
 			hasDoneFirstTimeSetup = false,
 			printDebugTextToChat = false,
 			printWhenLastSaved = false,
@@ -108,7 +109,7 @@ function AccWideUIAceAddon:GenerateDefaultDB()
 				tutorialTooltips = {
 					cvars = {}
 				},
-				battlefieldMap = { 
+				battlefieldMap = {
 					options = {},
 					cvars = {}
 				},
@@ -179,7 +180,7 @@ function AccWideUIAceAddon:GenerateDefaultDB()
 					cvarList = "",
 					cvarData = {},
 				}
-				
+
 			},
 			blizzChannels = {
 				['**'] = "default"
@@ -336,7 +337,7 @@ function AccWideUIAceAddon:GenerateOptions()
 										width = thisCheckboxWidth,
 										desc = L["ACCWUI_OPT_MODULES_CHK_PARTYRAID_DESC"],
 									},
-									
+
 								}
 							},
 							groupSocial = {
@@ -479,7 +480,7 @@ function AccWideUIAceAddon:GenerateOptions()
 										order = 205,
 										width = thisCheckboxWidth,
 										desc = L["ACCWUI_OPT_MODULES_CHK_WORLDMAP_DESC"],
-									},		
+									},
 									battlefieldMap = {
 										type = "toggle",
 										name = L["ACCWUI_OPT_MODULES_CHK_BTLMAP"],
@@ -493,9 +494,9 @@ function AccWideUIAceAddon:GenerateOptions()
 										order = 1100,
 										width = thisCheckboxWidth,
 										desc = L["ACCWUI_OPT_MODULES_CHK_UIMISC_DESC"],
-									},	
+									},
 								}
-							},							
+							},
 						},
 					},
 					headerDivExperimental = {
@@ -587,9 +588,9 @@ function AccWideUIAceAddon:GenerateOptions()
 						name = L["ACCWUI_OPT_MODULES_CVARS"],
 						desc = L["ACCWUI_OPT_MODULES_CVARS_DESC"]
 					},
-					
+
 				}
-				
+
 			},
 			channels = {
 				type = "group",
@@ -769,25 +770,32 @@ function AccWideUIAceAddon:GenerateOptions()
 								order = 4,
 								desc = L["ACCWUI_ADVANCED_DISABLE_AUTO_DESC"],
 							},
+							disableAutoSave = {
+								type = "toggle",
+								name = L["ACCWUI_ADVANCED_DISABLE_AUTOSAVE"],
+								width = "full",
+								order = 5,
+								desc = L["ACCWUI_ADVANCED_DISABLE_AUTOSAVE_DESC"],
+							},
 							btnForceLoad = {
 								type = "execute",
 								name = L["ACCWUI_DEBUG_BTN_FORCELOAD"],
 								desc = L["ACCWUI_DEBUG_BTN_FORCELOAD_DESC"],
-								order = 5,
-								func = function() 
-									self:ForceLoadSettings() 
+								order = 6,
+								func = function()
+									self:ForceLoadSettings()
 								end,
 							},
 							btnForceSave = {
 								type = "execute",
 								name = L["ACCWUI_DEBUG_BTN_FORCESAVE"],
 								desc = L["ACCWUI_DEBUG_BTN_FORCESAVE_DESC"],
-								order = 6,
-								func = function() 
-									self:ForceSaveSettings() 
+								order = 7,
+								func = function()
+									self:ForceSaveSettings()
 								end,
 							},
-							
+
 						}
 					},
 					debug = {
@@ -824,7 +832,7 @@ function AccWideUIAceAddon:GenerateOptions()
 								order = 6,
 								desc = L["ACCWUI_DEBUG_CHK_SHOWDEBUGPRINT_DESC"],
 							},
-							
+
 						}
 					},
 					utility = {
@@ -839,7 +847,7 @@ function AccWideUIAceAddon:GenerateOptions()
 								desc = L["ACCWUI_UTILITY_TXT_ZONEMAPPOS"],
 								width = 2,
 								order = 1,
-								func = function() 
+								func = function()
 									BattlefieldMapTab:ClearAllPoints()
 									BattlefieldMapTab:SetPoint("CENTER", UIParent, "CENTER", 0, 0)
 									--BattlefieldMapTab:Show()
@@ -849,7 +857,7 @@ function AccWideUIAceAddon:GenerateOptions()
 							},
 						}
 					},
-					
+
 					headerDiv1 = {
 						type = "header",
 						name = L["ACCWUI_ADDONNAME"],
@@ -869,23 +877,23 @@ function AccWideUIAceAddon:GenerateOptions()
 						width = "full",
 						name = L["ACCWUI_ISSUES"]
 					},
-					
-					
+
+
 				}
 			}
 		}
 	}
-	
-	
+
+
 	-- Edit Mode Specs
 	if (AccWideUIAceAddon:IsMainline() == true or AccWideUIAceAddon:IsClassicEra() == true) then
-	
+
 		local NumOfSpecs = GetNumSpecializations(false, false)
 
 		for ThisSpecX = 1, NumOfSpecs, 1 do
-			
+
 			local thisSpecName = PlayerUtil.GetSpecNameBySpecID(select(1, C_SpecializationInfo.GetSpecializationInfo(ThisSpecX)))
-		
+
 			self.optionsData.args.settings.args.editModeSettings.args["specialization" .. ThisSpecX] = {
 				type = "toggle",
 				name = thisSpecName,
@@ -896,26 +904,26 @@ function AccWideUIAceAddon:GenerateOptions()
 				desc = string.format(L["ACCWUI_CHARSPECIFIC_CHECK_DESC"], UnitNameUnmodified("player"), thisSpecName),
 			}
 		end
-	
+
 	else
 		self.optionsData.args.settings.args.editModeSettings = nil
 	end
-	
-	
-	
-	
-	
+
+
+
+
+
 	-- Remove Sync options that are not applicable to various versions
 	--[[if (AccWideUIAceAddon:IsMidnight() == true) then
 		self.optionsData.args.settings.args.syncToggles.args.groupUnits.args.nameplates = nil
 	end]]
-	
+
 	if (AccWideUIAceAddon:IsMidnight() ~= true) then
 		self.optionsData.args.settings.args.syncToggles.args.groupInterface.args.damageMeter = nil
 	end
-	
+
 	if (AccWideUIAceAddon:IsMainline() == false) then
-		self.optionsData.args.settings.args.editModeSettings = nil	
+		self.optionsData.args.settings.args.editModeSettings = nil
 		self.optionsData.args.settings.args.headerDiv2 = nil
 		self.optionsData.args.settings.args.syncToggles.args.groupInterface.args.cooldownViewer = nil
 		self.optionsData.args.settings.args.syncToggles.args.groupCombat.mouseoverCast = nil
@@ -923,20 +931,20 @@ function AccWideUIAceAddon:GenerateOptions()
 		self.optionsData.args.settings.args.syncToggles.args.groupCombat.assistedCombat = nil
 		self.optionsData.args.settings.args.syncToggles.args.groupSocial.args.locationVisibility = nil
 		self.optionsData.args.settings.args.syncToggles.args.groupSocial.args.blockNeighborhoodInvites = nil
-		
+
 		self.optionsData.args.settings.args.experimentalSyncToggles.args.bagOrganisation = nil
 		self.optionsData.args.advanced.args.advanced.args.allowExperimentalSyncs = nil
 	end
-	
+
 	if (AccWideUIAceAddon:IsMainline() == false and AccWideUIAceAddon:IsClassicTBC() == false) then
 		self.optionsData.args.settings.args.syncToggles.args.groupCombat.args.lossOfControl = nil
 		self.optionsData.args.settings.args.syncToggles.args.groupInterface.editModeLayout = nil
 	end
-	
+
 	if (AccWideUIAceAddon:IsClassicVanilla() == true) then
 		self.optionsData.args.settings.args.syncToggles.args.groupUnits.arenaFrames = nil
 	end
-	
+
 	if (AccWideUIAceAddon:IsMainline() == true or AccWideUIAceAddon:IsClassicProgression() == true) then
 		self.optionsData.args.settings.args.syncToggles.args.groupInterface.spellOverlay = nil
 	end
@@ -956,19 +964,19 @@ function AccWideUIAceAddon:GenerateOptions()
 	if (AccWideUIAceAddon:IsClassicEra() == false) then
 		self.optionsData.args.channels.args.hardcoreDeaths = nil
 	end
-	
+
 	if (AccWideUIAceAddon:IsMainline() == false and AccWideUIAceAddon:IsClassicEra() == false) then
 		self.optionsData.args.channels.args.services = nil
 	end
-	
-	
+
+
 	-- Hide Block Chat Channels if BlockBlizzChatChannels is installed
 	if (C_AddOns.IsAddOnLoaded("BlockBlizzChatChannels") == true) then
 		self.optionsData.args.channels = nil
 		self.optionsData.args.advanced.args.debug.args.printBlizzChatChanges = nil
 	end
-	
-	
+
+
 
 
 end

--- a/AccWideUILayoutSelection/locale/locale.enUS.lua
+++ b/AccWideUILayoutSelection/locale/locale.enUS.lua
@@ -140,6 +140,8 @@ L["ACCWUI_ADVANCED_ALLOW_EXP"] = "Allow Experimental Sync Settings"
 L["ACCWUI_ADVANCED_ALLOW_EXP_DESC"] = "When checked, a list of experimental sync settings will be available to use. \n\nThese sync settings may not always work depending on client and network conditions."
 L["ACCWUI_ADVANCED_DISABLE_AUTO"] = "Disable Auto Saving / Loading Settings"
 L["ACCWUI_ADVANCED_DISABLE_AUTO_DESC"] = "Normally, the addon will automatically save and load your settings when logging in, changing profile, and logging out.\n\nWhen checked, you will need to manually save and load your settings using the buttons below."
+L["ACCWUI_ADVANCED_DISABLE_AUTOSAVE"] = "Disable Auto Saving Only"
+L["ACCWUI_ADVANCED_DISABLE_AUTOSAVE_DESC"] = "When checked, the addon will NOT automatically save your settings when logging out, changing profile, or exiting Edit Mode.\n\nAutomatic loading will still occur when logging in or changing profile.\n\nUse this if you want to load settings but prevent accidental overwrites."
 
 L["ACCWUI_DEBUG_TITLE"] = BINDING_HEADER_DEBUG
 


### PR DESCRIPTION
My wife was looking for a quick change to only save when asked, I thought I would propose it back to you since it was pretty straight forward. 

Add new option to disable automatic saving while keeping automatic loading. This allows users to load settings but prevent accidental overwrites.

Changes:
- Add disableAutoSave toggle in Advanced Options
- Add condition checks for all 11 save operations
- Add locale strings for the new option
- Fix trailing whitespace in modified files